### PR TITLE
Implement some APIs for permissions and administering handles

### DIFF
--- a/docs/api/wwt_api_client.constellations.data.HandlePermissions.rst
+++ b/docs/api/wwt_api_client.constellations.data.HandlePermissions.rst
@@ -1,0 +1,25 @@
+HandlePermissions
+=================
+
+.. currentmodule:: wwt_api_client.constellations.data
+
+.. autoclass:: HandlePermissions
+   :show-inheritance:
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~HandlePermissions.from_dict
+      ~HandlePermissions.from_json
+      ~HandlePermissions.schema
+      ~HandlePermissions.to_dict
+      ~HandlePermissions.to_json
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: from_dict
+   .. automethod:: from_json
+   .. automethod:: schema
+   .. automethod:: to_dict
+   .. automethod:: to_json

--- a/docs/api/wwt_api_client.constellations.data.HandleUpdate.rst
+++ b/docs/api/wwt_api_client.constellations.data.HandleUpdate.rst
@@ -1,0 +1,25 @@
+HandleUpdate
+============
+
+.. currentmodule:: wwt_api_client.constellations.data
+
+.. autoclass:: HandleUpdate
+   :show-inheritance:
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~HandleUpdate.from_dict
+      ~HandleUpdate.from_json
+      ~HandleUpdate.schema
+      ~HandleUpdate.to_dict
+      ~HandleUpdate.to_json
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: from_dict
+   .. automethod:: from_json
+   .. automethod:: schema
+   .. automethod:: to_dict
+   .. automethod:: to_json

--- a/docs/api/wwt_api_client.constellations.handles.HandleClient.rst
+++ b/docs/api/wwt_api_client.constellations.handles.HandleClient.rst
@@ -17,6 +17,7 @@ HandleClient
       ~HandleClient.get
       ~HandleClient.get_timeline
       ~HandleClient.permissions
+      ~HandleClient.update
 
    .. rubric:: Methods Documentation
 
@@ -27,3 +28,4 @@ HandleClient
    .. automethod:: get
    .. automethod:: get_timeline
    .. automethod:: permissions
+   .. automethod:: update

--- a/docs/api/wwt_api_client.constellations.handles.HandleClient.rst
+++ b/docs/api/wwt_api_client.constellations.handles.HandleClient.rst
@@ -16,6 +16,7 @@ HandleClient
       ~HandleClient.add_scene_from_place
       ~HandleClient.get
       ~HandleClient.get_timeline
+      ~HandleClient.permissions
 
    .. rubric:: Methods Documentation
 
@@ -25,3 +26,4 @@ HandleClient
    .. automethod:: add_scene_from_place
    .. automethod:: get
    .. automethod:: get_timeline
+   .. automethod:: permissions

--- a/docs/endpoints/constellations/get-handle-_handle-permissions.rst
+++ b/docs/endpoints/constellations/get-handle-_handle-permissions.rst
@@ -1,0 +1,38 @@
+.. _endpoint-GET-handle-_handle-permissions:
+
+===============================
+GET /handle/:handle/permissions
+===============================
+
+This API returns JSON capturing the logged-in user's permissions with regards to
+the specified handle.
+
+The returned information is purely advisory. The final arbiters of what is
+actually allowed are the checks implemented for the actual APIs. Furthermore, it
+is always possible that the results of this API call end up being out-of-date by
+the time that you attempt to act on them. So in almost all circumstances, you
+should ignore this API and just attempt the operation that you want to attempt,
+and handle any errors that might happen. This API should only be used to
+construct UIs that may choose to hide or show certain elements based on the
+user's permissions.
+
+
+Request Structure
+=================
+
+The request takes no content. The ``:handle`` URL parameter gives the handle to
+query.
+
+
+Response Structure
+==================
+
+The response is as follows:
+
+.. code-block:: javascript
+
+  {
+    "error": $bool // Whether an error occurred
+    "handle": $string, // the handle that was queried
+    "view_dashboard": $boolean, // whether the user can view the handle's admin "dashboard'
+  }

--- a/docs/endpoints/constellations/patch-handle-_handle.rst
+++ b/docs/endpoints/constellations/patch-handle-_handle.rst
@@ -1,0 +1,41 @@
+.. _endpoint-PATCH-handle-_handle:
+
+=====================
+PATCH /handle/:handle
+=====================
+
+This API updates various attributes of the specified handle.
+
+
+Authorization
+=============
+
+The request must be made by an account that has permissions to make *all* of the
+requested modifications. If any of the requested modifications are disallowed,
+the entire operation fails.
+
+
+Request Structure
+=================
+
+The URL parameter ``:handle`` is the handle that will be modified
+
+The structure of the request is:
+
+.. code-block:: javascript
+
+  {
+    "display_name": $string?,  // A new display name for the handle
+  }
+
+
+Response Structure
+==================
+
+The structure of the response is:
+
+.. code-block:: javascript
+
+  {
+    "error": $bool // Whether an error occurred
+  }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,6 +47,7 @@ Constellations API endpoints:
 
    endpoints/constellations/get-handle-_handle
    endpoints/constellations/post-handle-_handle-image
+   endpoints/constellations/get-handle-_handle-permissions
    endpoints/constellations/post-handle-_handle-scene
    endpoints/constellations/get-handle-_handle-timeline
    endpoints/constellations/get-image-_id-img_wtml

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,7 @@ Constellations API endpoints:
    :maxdepth: 1
 
    endpoints/constellations/get-handle-_handle
+   endpoints/constellations/patch-handle-_handle
    endpoints/constellations/post-handle-_handle-image
    endpoints/constellations/get-handle-_handle-permissions
    endpoints/constellations/post-handle-_handle-scene

--- a/wwt_api_client/constellations/data.py
+++ b/wwt_api_client/constellations/data.py
@@ -13,6 +13,7 @@ from dataclasses_json import config, dataclass_json
 __all__ = """
 HandleInfo
 HandlePermissions
+HandleUpdate
 ImageDisplayInfo
 ImageStorage
 ImageSummary
@@ -63,6 +64,12 @@ class HandleInfo:
 class HandlePermissions:
     handle: str
     view_dashboard: bool
+
+
+@dataclass_json
+@dataclass
+class HandleUpdate:
+    display_name: Optional[str]
 
 
 @dataclass_json

--- a/wwt_api_client/constellations/data.py
+++ b/wwt_api_client/constellations/data.py
@@ -12,6 +12,7 @@ from dataclasses_json import config, dataclass_json
 
 __all__ = """
 HandleInfo
+HandlePermissions
 ImageDisplayInfo
 ImageStorage
 ImageSummary
@@ -55,6 +56,13 @@ def _strip_nulls_in_place(d: dict):
 class HandleInfo:
     handle: str
     display_name: str
+
+
+@dataclass_json
+@dataclass
+class HandlePermissions:
+    handle: str
+    view_dashboard: bool
 
 
 @dataclass_json

--- a/wwt_api_client/constellations/handles.py
+++ b/wwt_api_client/constellations/handles.py
@@ -20,6 +20,7 @@ from wwt_data_formats.place import Place
 from . import CxClient, TimelineResponse
 from .data import (
     HandleInfo,
+    HandlePermissions,
     ImageWwt,
     ImageStorage,
     SceneContent,
@@ -105,6 +106,23 @@ class HandleClient:
         resp = resp.json()
         resp.pop("error")
         return HandleInfo.schema().load(resp)
+
+    def permissions(self) -> HandlePermissions:
+        """
+        Get information about the logged-in user's permissions with regards to
+        this handle.
+
+        This method corresponds to the :ref:`endpoint-GET-handle-_handle-permissions`
+        API endpoint. See that documentation for important guidance about when
+        and how to use this API. In most cases you should not use it, and just
+        go ahead and attempt whatever operation wish to perform.
+        """
+        resp = self.client._send_and_check(
+            self._url_base + "/permissions", http_method="GET"
+        )
+        resp = resp.json()
+        resp.pop("error")
+        return HandlePermissions.schema().load(resp)
 
     def add_image(self, image: AddImageRequest) -> str:
         """

--- a/wwt_api_client/constellations/handles.py
+++ b/wwt_api_client/constellations/handles.py
@@ -21,6 +21,7 @@ from . import CxClient, TimelineResponse
 from .data import (
     HandleInfo,
     HandlePermissions,
+    HandleUpdate,
     ImageWwt,
     ImageStorage,
     SceneContent,
@@ -123,6 +124,23 @@ class HandleClient:
         resp = resp.json()
         resp.pop("error")
         return HandlePermissions.schema().load(resp)
+
+    def update(self, updates: HandleUpdate):
+        """
+        Update various attributes of this handle
+
+        This method corresponds to the :ref:`endpoint-PATCH-handle-_handle` API
+        endpoint.
+        """
+        resp = self.client._send_and_check(
+            self._url_base,
+            http_method="PATCH",
+            json=_strip_nulls_in_place(updates.to_dict()),
+        )
+        resp = resp.json()
+        resp.pop("error")
+        # Might as well return the response, although it's currently vacuous
+        return resp
 
     def add_image(self, image: AddImageRequest) -> str:
         """


### PR DESCRIPTION
This exposes the functionality implemented in https://github.com/WorldWideTelescope/wwt-constellations-backend/pull/11 .