### PR TITLE
Update Constellations APIs to account for scene previews

### DIFF
--- a/wwt_api_client/constellations/data.py
+++ b/wwt_api_client/constellations/data.py
@@ -29,6 +29,7 @@ SceneImageLayerHydrated
 SceneInfo
 ScenePermissions
 ScenePlace
+ScenePreviews
 """.split()
 
 
@@ -183,6 +184,13 @@ class SceneContentHydrated:
 
 @dataclass_json
 @dataclass
+class ScenePreviews:
+    video: Optional[str]
+    thumbnail: Optional[str]
+
+
+@dataclass_json
+@dataclass
 class SceneHydrated:
     id: str
     handle_id: str
@@ -192,6 +200,7 @@ class SceneHydrated:
     place: ScenePlace
     content: SceneContentHydrated
     text: str
+    previews: ScenePreviews
 
 
 @dataclass_json
@@ -208,3 +217,4 @@ class SceneInfo:
 class ScenePermissions:
     id: str
     edit: bool
+


### PR DESCRIPTION
This PR updates the Constellations APIs to include information about scene previews (see https://github.com/WorldWideTelescope/wwt-constellations-backend/pull/14). This is done by adding a `ScenePreviews` data class and adding this to `SceneContentHydrated`.