### PR TITLE
Image permissions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup_args = dict(
     include_package_data=True,
     install_requires=[
         "dataclasses-json >=0.5",
+        "license-expression >=21.6",
         "openidc_client >=0.6",
         "requests >=2.10",
         "wwt_data_formats >=0.16",

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup_args = dict(
     include_package_data=True,
     install_requires=[
         "dataclasses-json >=0.5",
+        "html-sanitizer",
         "license-expression >=21.6",
         "openidc_client >=0.6",
         "requests >=2.10",

--- a/wwt_api_client/constellations/data.py
+++ b/wwt_api_client/constellations/data.py
@@ -10,6 +10,8 @@ from typing import List, Optional
 from dataclasses import dataclass, field
 from dataclasses_json import config, dataclass_json
 
+from license_expression import get_spdx_licensing, ExpressionError
+
 __all__ = """
 HandleImageStats
 HandleInfo
@@ -18,6 +20,7 @@ HandleSceneStats
 HandleStats
 HandleUpdate
 ImageDisplayInfo
+ImagePermissions
 ImageStorage
 ImageSummary
 ImageWwt
@@ -147,6 +150,12 @@ class ImagePermissions:
     copyright: str
     credits: Optional[str]
     license: str
+
+    def __post_init__(self):
+        license_info = get_spdx_licensing().validate(self.license, strict=True)
+        if license_info.errors:
+            msg = "\n".join(license_info.errors)
+            raise ExpressionError(f"Invalid SPDX license:\n{msg}")
 
 
 @dataclass_json

--- a/wwt_api_client/constellations/data.py
+++ b/wwt_api_client/constellations/data.py
@@ -143,6 +143,14 @@ class ImageSummary:
 
 @dataclass_json
 @dataclass
+class ImagePermissions:
+    copyright: str
+    credits: Optional[str]
+    license: str
+
+
+@dataclass_json
+@dataclass
 class ImageDisplayInfo:
     wwt: ImageWwt
     storage: ImageStorage

--- a/wwt_api_client/constellations/data.py
+++ b/wwt_api_client/constellations/data.py
@@ -10,7 +10,7 @@ from typing import List, Optional
 from dataclasses import dataclass, field
 from dataclasses_json import config, dataclass_json
 
-from html_sanitizer import Sanitizer
+from html_sanitizer.sanitizer import Sanitizer, DEFAULT_SETTINGS
 from license_expression import get_spdx_licensing, ExpressionError
 
 __all__ = """
@@ -39,7 +39,9 @@ SceneUpdate
 
 
 CX_LICENSING = get_spdx_licensing()
-CX_SANITIZER = Sanitizer(dict(tags={"b", "strong", "i", "a", "br"}, empty={}, separate={}))
+CX_SANITIZER_SETTINGS = DEFAULT_SETTINGS.copy()
+CX_SANITIZER_SETTINGS.update(tags={"b", "strong", "i", "em", "a", "br"}, empty={}, separate={})
+CX_SANITIZER = Sanitizer(settings=CX_SANITIZER_SETTINGS)
 
 
 def _strip_nulls_in_place(d: dict):

--- a/wwt_api_client/tests/test_constellations.py
+++ b/wwt_api_client/tests/test_constellations.py
@@ -1,0 +1,39 @@
+from license_expression import ExpressionError
+import pytest
+
+from ..constellations.data import ImagePermissions
+
+
+@pytest.fixture
+def valid_permissions_data():
+    return {
+        "copyright": "Some copyright information",
+        "credits": "<strong>Image Credit:</strong> Someone",
+        "license": "BSD-2-Clause"
+    }
+
+
+def test_valid_image_permissions(valid_permissions_data):
+    permissions = ImagePermissions(**valid_permissions_data)
+
+    assert permissions.copyright == valid_permissions_data["copyright"]
+    assert permissions.credits == valid_permissions_data["credits"]
+    assert permissions.license == valid_permissions_data["license"]
+
+
+def test_invalid_permissions_license(valid_permissions_data):
+    with pytest.raises(ExpressionError):
+        permissions_data = valid_permissions_data.copy()
+        permissions_data["license"] = "NO SUCH LICENSE"
+        ImagePermissions(**permissions_data)
+
+
+def test_sanitize_permissions_html(valid_permissions_data):
+    permissions_data = valid_permissions_data.copy()
+    permissions_data["credits"] = "<script>Some JS here</script><a>Credits Link</a>"
+    permissions = ImagePermissions(**permissions_data)
+
+    assert permissions.copyright == permissions_data["copyright"]
+    assert permissions.license == permissions_data["license"]
+    assert permissions.credits == "<a>Credits Link</a>"
+


### PR DESCRIPTION
This PR is the companion to https://github.com/WorldWideTelescope/wwt-constellations-backend/pull/17. It creates an `ImagePermissions` dataclass to match the schema defined in that PR. SPDX license expressions are validated using the `license_expression` package, and credits HTML (if present) is sanitized with `html-sanitizer`.