### PR TITLE
Updates for background editing APIs

### DIFF
--- a/docs/api/wwt_api_client.constellations.CxClient.rst
+++ b/docs/api/wwt_api_client.constellations.CxClient.rst
@@ -11,6 +11,7 @@ CxClient
    .. autosummary::
 
       ~CxClient.find_images_by_wwt_url
+      ~CxClient.get_builtin_backgrounds
       ~CxClient.get_home_timeline
       ~CxClient.handle_client
       ~CxClient.image_client
@@ -19,6 +20,7 @@ CxClient
    .. rubric:: Methods Documentation
 
    .. automethod:: find_images_by_wwt_url
+   .. automethod:: get_builtin_backgrounds
    .. automethod:: get_home_timeline
    .. automethod:: handle_client
    .. automethod:: image_client

--- a/docs/endpoints/constellations/get-image-_id.rst
+++ b/docs/endpoints/constellations/get-image-_id.rst
@@ -60,3 +60,6 @@ The structure of the response is:
     },
     "note": $string, // A textual note associated with this image
   }
+
+See :ref:`endpoint-post-handle-_handle-image` for definitions of the contents of the inner
+image fields.

--- a/docs/endpoints/constellations/get-images-builtin-backgrounds.rst
+++ b/docs/endpoints/constellations/get-images-builtin-backgrounds.rst
@@ -1,0 +1,41 @@
+.. _endpoint-GET-images-builtin-backgrounds:
+
+===============================
+GET /images/builtin-backgrounds
+===============================
+
+This API returns a list of images that constitute the set of built-in background
+images suggested to users.
+
+
+Request Structure
+=================
+
+The request takes no content.
+
+
+Response Structure
+==================
+
+The structure of the response is:
+
+.. code-block:: javascript
+
+  {
+    "error": $bool // Whether an error occurred
+    "results": [
+      // List of image display objects:
+      {
+        "_id": $string(objectID), // the ID of this image in the database
+        "handle_id": $string(objectID), // the ID of this image's owner
+        "creation_date": $string(iso8601), // the date this image record was created
+        "note": $string, // freeform text associated with the image
+        "storage": {
+          "legacy_url_template": $string // This image's legacy URL
+        }
+      }
+    ]
+  }
+
+See :ref:`endpoint-post-handle-_handle-image` for definitions of the contents of
+the inner fields.

--- a/docs/endpoints/constellations/get-scene-_id.rst
+++ b/docs/endpoints/constellations/get-scene-_id.rst
@@ -31,6 +31,8 @@ The structure of the response is:
     },
     "creation_date": $string(iso8601), // the date this scene was created
     "likes": $number, // the number of likes this scene has received
+    "liked": $bool, // whether the logged-in user has "liked" this scene
+    "impressions": $number, // the number of impressions this scene has received
     "place": { // WWT camera information associated with this scene
       // See "POST /handle/:handle/scene" docs for descriptions:
       "ra_rad": $number,
@@ -42,38 +44,29 @@ The structure of the response is:
     "content": { // The contents of this scene
       // Eventually, multiple content forms will likely be supported.
       // For now, the only one is the `image_layers` structure.
-      "background_id": $string(objectID), // The ID of the background imageset associated with this scene
       "image_layers": [
         // List of "hydrated" image layer records:
         {
           "image": {
-            "wwt": {
-              // Astrometric/data fields used by WWT, as in `POST /handle/:handle/image`;
-              // see the `wwt_data_formats` documentation for definitions of these fields
-              "base_degrees_per_tile": $number,
-              "bottoms_up": $boolean,
-              "center_x": $number,
-              "center_y": $number,
-              "file_type": $string,
-              "offset_x": $number,
-              "offset_y": $number,
-              "projection": $string,
-              "quad_tree_map": $string,
-              "rotation": $number,
-              "thumbnail_url": $string,
-              "tile_levels": $number(int),
-              "width_factor": $number(int),
-            }
-            "storage": {
-              // Data storage information as in `POST /handle/:handle/image`
-              // For now, this is the only valid storage type:
-              "legacy_url_template": $string // This image's legacy URL
-            }
+            "id": $string, // the ID of this image
+            "wwt": { ... },
+            "permissions": { ... },
+            "storage": { ... },
           },
           "opacity": $number, // between 0 and 1
         }
       ],
+      "background": {
+        // Another "hydrated" image record:
+        "id": $string, // the ID of this image
+        "wwt": { ... },
+        "permissions": { ... },
+        "storage": { ... },
+      },
     },
     "text": $string, // The text associated with this scene
     "outgoing_url": $string(URL)?, // optional outgoing URL associated with this scene
   }
+
+See :ref:`endpoint-post-handle-_handle-image` for definitions of the contents of the inner
+image fields.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,6 +58,7 @@ Constellations API endpoints:
    endpoints/constellations/patch-image-_id
    endpoints/constellations/get-image-_id-img_wtml
    endpoints/constellations/get-image-_id-permissions
+   endpoints/constellations/get-images-builtin-backgrounds
    endpoints/constellations/post-images-find-by-legacy-url
    endpoints/constellations/get-scene-_id
    endpoints/constellations/patch-scene-_id

--- a/wwt_api_client/constellations/__init__.py
+++ b/wwt_api_client/constellations/__init__.py
@@ -162,6 +162,9 @@ class TimelineResponse:
     results: List[SceneHydrated]
 
 
+BuiltinBackgroundsResponse = FindImagesByLegacyResponse
+
+
 # I think this is unlikely to ever need to be configurable?
 _ID_PROVIDER_MAPPING = {
     "Authorization": "/protocol/openid-connect/auth",
@@ -330,4 +333,17 @@ class CxClient:
         resp = resp.json()
         resp.pop("error")
         resp = TimelineResponse.schema().load(resp)
+        return resp.results
+
+    def get_builtin_backgrounds(self) -> List[ImageSummary]:
+        """
+        Get the list of builtin background imagery options.
+
+        This method corresponds to the
+        :ref:`endpoint-GET-images-builtin-backgrounds` API endpoint.
+        """
+        resp = self._send_and_check("/images/builtin-backgrounds", http_method="GET")
+        resp = resp.json()
+        resp.pop("error")
+        resp = BuiltinBackgroundsResponse.schema().load(resp)
         return resp.results

--- a/wwt_api_client/constellations/__init__.py
+++ b/wwt_api_client/constellations/__init__.py
@@ -144,19 +144,19 @@ class ClientConfig:
         )
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class FindImagesByLegacyRequest:
     wwt_legacy_url: str
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class FindImagesByLegacyResponse:
     results: List[ImageSummary]
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class TimelineResponse:
     results: List[SceneHydrated]

--- a/wwt_api_client/constellations/data.py
+++ b/wwt_api_client/constellations/data.py
@@ -91,7 +91,7 @@ class HandlePermissions:
 @dataclass_json
 @dataclass
 class HandleUpdate:
-    display_name: Optional[str]
+    display_name: Optional[str] = None
 
 
 @dataclass_json
@@ -141,7 +141,7 @@ class ImageWwt:
 class ImageStorage:
     """A description of data storage associated with a Constellations image."""
 
-    legacy_url_template: Optional[str]
+    legacy_url_template: Optional[str] = None
 
 
 @dataclass_json
@@ -199,8 +199,8 @@ class ImageInfo:
 @dataclass_json
 @dataclass
 class ImageUpdate:
-    note: Optional[str]
-    permissions: Optional[ImageContentPermissions]
+    note: Optional[str] = None
+    permissions: Optional[ImageContentPermissions] = None
 
 
 @dataclass_json
@@ -230,7 +230,7 @@ class SceneImageLayer:
 @dataclass_json
 @dataclass
 class SceneContent:
-    image_layers: Optional[List[SceneImageLayer]]
+    image_layers: Optional[List[SceneImageLayer]] = None
 
 
 @dataclass_json
@@ -243,15 +243,15 @@ class SceneImageLayerHydrated:
 @dataclass_json
 @dataclass
 class SceneContentHydrated:
-    background: Optional[ImageDisplayInfo]
-    image_layers: Optional[List[SceneImageLayerHydrated]]
+    background: Optional[ImageDisplayInfo] = None
+    image_layers: Optional[List[SceneImageLayerHydrated]] = None
 
 
 @dataclass_json
 @dataclass
 class ScenePreviews:
-    video: Optional[str]
-    thumbnail: Optional[str]
+    video: Optional[str] = None
+    thumbnail: Optional[str] = None
 
 
 @dataclass_json

--- a/wwt_api_client/constellations/data.py
+++ b/wwt_api_client/constellations/data.py
@@ -74,33 +74,33 @@ def _strip_nulls_in_place(d: dict):
     return d
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class HandleInfo:
     handle: str
     display_name: str
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class HandlePermissions:
     handle: str
     view_dashboard: bool
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class HandleUpdate:
     display_name: Optional[str] = None
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class HandleImageStats:
     count: int
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class HandleSceneStats:
     count: int
@@ -108,7 +108,7 @@ class HandleSceneStats:
     likes: int
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class HandleStats:
     handle: str
@@ -116,7 +116,7 @@ class HandleStats:
     scenes: HandleSceneStats
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class ImageWwt:
     """A description of the WWT data parameters associated with a Constellations image."""
@@ -136,7 +136,7 @@ class ImageWwt:
     thumbnail_url: str
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class ImageStorage:
     """A description of data storage associated with a Constellations image."""
@@ -144,7 +144,7 @@ class ImageStorage:
     legacy_url_template: Optional[str] = None
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class ImageSummary:
     """Summary information about a Constellations image."""
@@ -156,7 +156,7 @@ class ImageSummary:
     storage: ImageStorage
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class ImageContentPermissions:
     copyright: str
@@ -172,7 +172,7 @@ class ImageContentPermissions:
             self.credits = CX_SANITIZER.sanitize(self.credits)
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class ImageDisplayInfo:
     id: str  # 24 hex digits
@@ -181,7 +181,7 @@ class ImageDisplayInfo:
     storage: ImageStorage
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class ImageInfo:
     """Note that this class is *not* what is returned by the
@@ -198,21 +198,21 @@ class ImageInfo:
     note: str
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class ImageUpdate:
     note: Optional[str] = None
     permissions: Optional[ImageContentPermissions] = None
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class ImageApiPermissions:
     id: str
     edit: bool
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class ScenePlace:
     ra_rad: float
@@ -222,41 +222,41 @@ class ScenePlace:
     roi_aspect_ratio: float
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class SceneImageLayer:
     image_id: str
     opacity: float
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class SceneContent:
     image_layers: Optional[List[SceneImageLayer]] = None
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class SceneImageLayerHydrated:
     image: ImageDisplayInfo
     opacity: float
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class SceneContentHydrated:
     background: Optional[ImageDisplayInfo] = None
     image_layers: Optional[List[SceneImageLayerHydrated]] = None
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class ScenePreviews:
     video: Optional[str] = None
     thumbnail: Optional[str] = None
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class SceneHydrated:
     id: str
@@ -270,7 +270,7 @@ class SceneHydrated:
     previews: ScenePreviews
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class SceneInfo:
     _id: str
@@ -279,14 +279,14 @@ class SceneInfo:
     likes: int
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class ScenePermissions:
     id: str
     edit: bool
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class SceneUpdate:
     outgoing_url: Optional[str]

--- a/wwt_api_client/constellations/data.py
+++ b/wwt_api_client/constellations/data.py
@@ -175,7 +175,9 @@ class ImageContentPermissions:
 @dataclass_json
 @dataclass
 class ImageDisplayInfo:
+    id: str  # 24 hex digits
     wwt: ImageWwt
+    permissions: ImageContentPermissions
     storage: ImageStorage
 
 

--- a/wwt_api_client/constellations/data.py
+++ b/wwt_api_client/constellations/data.py
@@ -264,6 +264,8 @@ class SceneHydrated:
     handle: HandleInfo
     creation_date: str
     likes: int
+    liked: bool
+    impressions: int
     place: ScenePlace
     content: SceneContentHydrated
     text: str

--- a/wwt_api_client/constellations/handles.py
+++ b/wwt_api_client/constellations/handles.py
@@ -46,7 +46,7 @@ H2R = math.pi / 12
 D2R = math.pi / 180
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class AddImageRequest:
     wwt: ImageWwt
@@ -55,14 +55,14 @@ class AddImageRequest:
     note: str
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class AddImageResponse:
     id: str
     rel_url: str
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class AddSceneRequest:
     place: ScenePlace
@@ -71,21 +71,21 @@ class AddSceneRequest:
     text: str
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class AddSceneResponse:
     id: str
     rel_url: str
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class ImageInfoResponse:
     total_count: int
     results: List[ImageSummary]
 
 
-@dataclass_json
+@dataclass_json(undefined="EXCLUDE")
 @dataclass
 class SceneInfoResponse:
     total_count: int


### PR DESCRIPTION
This builds on https://github.com/WorldWideTelescope/wwt-constellations-backend/pull/25 . We also correct some unrelated issues, including (finally) the ability to omit optional fields and (double finally) having the JSON deserializer ignore fields that it doesn't know about.