### PR TITLE
wwt_api_client/constellations/data.py: fix some more optional fields

### DIFF
--- a/wwt_api_client/constellations/data.py
+++ b/wwt_api_client/constellations/data.py
@@ -172,8 +172,8 @@ class ImageSummary:
 @dataclass
 class ImageContentPermissions:
     copyright: str
-    credits: Optional[str]
     license: str
+    credits: Optional[str] = None
 
     def __post_init__(self):
         license_info = CX_LICENSING.validate(self.license, strict=True)
@@ -303,6 +303,6 @@ class ScenePermissions:
 @dataclass_json(undefined="EXCLUDE")
 @dataclass
 class SceneUpdate:
-    outgoing_url: Optional[str]
-    place: Optional[ScenePlace]
-    text: Optional[str]
+    outgoing_url: Optional[str] = None
+    place: Optional[ScenePlace] = None
+    text: Optional[str] = None


### PR DESCRIPTION
Note that we need to reorder ImageContentPermissions because otherwise the automatically generated constructor gets an error about non-optional arguments following optional ones.