### PR TITLE
Update the "front door" email address to hello@worldwidetelescope.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![PyPI version](https://badge.fury.io/py/wwt-api-client.svg)](https://badge.fury.io/py/wwt-api-client)
 [![codecov](https://codecov.io/gh/WorldWideTelescope/wwt_api_client/branch/master/graph/badge.svg?token=R7hIYRRRCl)](https://codecov.io/gh/WorldWideTelescope/wwt_api_client)
 
-# `wwt_api_client`: Accessing AAS WorldWide Telescope Web Service from Python
+# `wwt_api_client`: Accessing WorldWide Telescope Web Services from Python
 
 <!--pypi-begin-->
 The [wwt_api_client] package provides a Python interface to the various web
-services that power the [AAS](https://aas.org/) [WorldWide
-Telescope](https://worldwidetelescope.org/) project.
+services that power the [WorldWide Telescope](https://worldwidetelescope.org/)
+project.
 
 [wwt_api_client]: https://wwt-api-client.readthedocs.io/
 <!--pypi-end-->
@@ -72,7 +72,7 @@ All participation in WWT communities is conditioned on your adherence to the
 
 ## Acknowledgments
 
-The AAS WorldWide Telescope system is a [.NET Foundation] project. Work on WWT
+The WorldWide Telescope system is a [.NET Foundation] project. Work on WWT
 has been supported by the [American Astronomical Society] (AAS), the US
 [National Science Foundation] (grants [1550701], [1642446], and [2004840]), the [Gordon
 and Betty Moore Foundation], and [Microsoft].

--- a/setup.py
+++ b/setup.py
@@ -35,11 +35,11 @@ project homepage].
 setup_args = dict(
     name="wwt_api_client",  # cranko project-name
     version="0.dev0",  # cranko project-version
-    description="An API client for the AAS WorldWide Telescope web services",
+    description="An API client for WorldWide Telescope web services",
     long_description=get_long_desc(),
     long_description_content_type="text/markdown",
-    author="AAS WorldWide Telescope Team",
-    author_email="wwt@aas.org",
+    author="WorldWide Telescope Team",
+    author_email="hello@worldwidetelescope.org",
     url="https://github.com/WorldWideTelescope/wwt_api_client",
     packages=[
         "wwt_api_client",


### PR DESCRIPTION
This is yet another part of the sponsorship migration.

Related pull requests cross-linked at: https://github.com/WorldWideTelescope/worldwidetelescope.github.io/pull/88

Also update some other bits that need changing for the migration.