### PR TITLE
Updates for scene publishing

### DIFF
--- a/docs/api/wwt_api_client.constellations.data.SceneContentUpdate.rst
+++ b/docs/api/wwt_api_client.constellations.data.SceneContentUpdate.rst
@@ -1,0 +1,37 @@
+SceneContentUpdate
+==================
+
+.. currentmodule:: wwt_api_client.constellations.data
+
+.. autoclass:: SceneContentUpdate
+   :show-inheritance:
+
+   .. rubric:: Attributes Summary
+
+   .. autosummary::
+
+      ~SceneContentUpdate.background_id
+      ~SceneContentUpdate.dataclass_json_config
+
+   .. rubric:: Methods Summary
+
+   .. autosummary::
+
+      ~SceneContentUpdate.from_dict
+      ~SceneContentUpdate.from_json
+      ~SceneContentUpdate.schema
+      ~SceneContentUpdate.to_dict
+      ~SceneContentUpdate.to_json
+
+   .. rubric:: Attributes Documentation
+
+   .. autoattribute:: background_id
+   .. autoattribute:: dataclass_json_config
+
+   .. rubric:: Methods Documentation
+
+   .. automethod:: from_dict
+   .. automethod:: from_json
+   .. automethod:: schema
+   .. automethod:: to_dict
+   .. automethod:: to_json

--- a/docs/api/wwt_api_client.constellations.data.SceneUpdate.rst
+++ b/docs/api/wwt_api_client.constellations.data.SceneUpdate.rst
@@ -10,9 +10,11 @@ SceneUpdate
 
    .. autosummary::
 
+      ~SceneUpdate.content
       ~SceneUpdate.dataclass_json_config
       ~SceneUpdate.outgoing_url
       ~SceneUpdate.place
+      ~SceneUpdate.published
       ~SceneUpdate.text
 
    .. rubric:: Methods Summary
@@ -27,9 +29,11 @@ SceneUpdate
 
    .. rubric:: Attributes Documentation
 
+   .. autoattribute:: content
    .. autoattribute:: dataclass_json_config
    .. autoattribute:: outgoing_url
    .. autoattribute:: place
+   .. autoattribute:: published
    .. autoattribute:: text
 
    .. rubric:: Methods Documentation

--- a/wwt_api_client/constellations/data.py
+++ b/wwt_api_client/constellations/data.py
@@ -323,4 +323,4 @@ class SceneUpdate:
     place: Optional[ScenePlace] = None
     text: Optional[str] = None
     content: Optional[SceneContentUpdate] = None
-    publish: Optional[bool] = None
+    published: Optional[bool] = None

--- a/wwt_api_client/constellations/data.py
+++ b/wwt_api_client/constellations/data.py
@@ -286,6 +286,7 @@ class SceneHydrated:
     content: SceneContentHydrated
     text: str
     previews: ScenePreviews
+    published: bool
 
 
 @dataclass_json(undefined="EXCLUDE")
@@ -297,6 +298,8 @@ class SceneInfo:
     likes: int
     clicks: Optional[int]
     shares: Optional[int]
+    text: str
+    published: bool
 
 
 @dataclass_json(undefined="EXCLUDE")
@@ -308,7 +311,15 @@ class ScenePermissions:
 
 @dataclass_json(undefined="EXCLUDE")
 @dataclass
+class SceneContentUpdate:
+    background_id: Optional[str] = None
+
+
+@dataclass_json(undefined="EXCLUDE")
+@dataclass
 class SceneUpdate:
     outgoing_url: Optional[str] = None
     place: Optional[ScenePlace] = None
     text: Optional[str] = None
+    content: Optional[SceneContentUpdate] = None
+    publish: Optional[bool] = None

--- a/wwt_api_client/constellations/data.py
+++ b/wwt_api_client/constellations/data.py
@@ -35,6 +35,7 @@ ImageUpdate
 ImageWwt
 SceneContent
 SceneContentHydrated
+SceneContentUpdate
 SceneHydrated
 SceneImageLayer
 SceneImageLayerHydrated

--- a/wwt_api_client/constellations/handles.py
+++ b/wwt_api_client/constellations/handles.py
@@ -70,7 +70,7 @@ class AddSceneRequest:
     place: ScenePlace
     content: SceneContent
     text: str
-    publish: bool
+    published: bool
     outgoing_url: Optional[str] = None
 
 
@@ -456,7 +456,7 @@ class HandleClient:
         resp = AddSceneResponse.schema().load(resp)
         return resp.id
 
-    def add_scene_from_place(self, place: Place) -> str:
+    def add_scene_from_place(self, place: Place, publish=True) -> str:
         """
         Add a new scene derived from a :class:`wwt_data_formats.place.Place`
         object.
@@ -465,6 +465,8 @@ class HandleClient:
         ----------
         place : :class:`wwt_data_formats.place.Place`
             The WWT place
+        publish: `bool`
+            Whether or not to publish the newly-created scene
 
         Returns
         -------
@@ -533,7 +535,7 @@ class HandleClient:
             content=content,
             text=text,
             outgoing_url=outgoing_url,
-            publish=True,
+            published=publish,
         )
 
         return self.add_scene(req)

--- a/wwt_api_client/constellations/handles.py
+++ b/wwt_api_client/constellations/handles.py
@@ -70,6 +70,7 @@ class AddSceneRequest:
     place: ScenePlace
     content: SceneContent
     text: str
+    publish: bool
     outgoing_url: Optional[str] = None
 
 
@@ -187,7 +188,7 @@ class HandleClient:
         page_num : int
             Which page to retrieve. Page zero gives the most recently-created
             scenes, page one gives the next batch, etc.
-        page_size : optinal int, defaults to 10
+        page_size : optional int, defaults to 10
             The number of items per page to retrieve. Valid values are between
             1 and 100.
 
@@ -532,6 +533,7 @@ class HandleClient:
             content=content,
             text=text,
             outgoing_url=outgoing_url,
+            publish=True,
         )
 
         return self.add_scene(req)


### PR DESCRIPTION
This PR updates the client data structures and creating a scene from a place to account for the backend changes in https://github.com/WorldWideTelescope/wwt-constellations-backend/pull/41. I've also added a `content` field to `SceneUpdate` to match what exists on the backend.